### PR TITLE
Skip tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ drush-reloadp -s @source.alias -d @dest.alias
 ## Advanced usage
 
 ```bash
-drush-reloadp -s <source.alias> -d <dest.alias> [-t <table1>[,<table2>...]] [-vr]
+$ drush-reloadp -s <source.alias> -d <dest.alias> [-t <table1>[,<table2>...]] [-vr]
 
 Options:
   -s, --source       The source drush alias to dump the database from.                  [required]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ $ npm install -g drush-reloadp
 $ drush-reloadp -s @source.alias -d @dest.alias
 ```
 
+## Advanced usage
+
+```bash
+drush-reloadp -s <source.alias> -d <dest.alias> [-t <table1>[,<table2>...]] [-vr]
+
+Options:
+  -s, --source       The source drush alias to dump the database from.                  [required]
+  -d, --dest         The destination drush alias to import the database to.             [required]
+  -v, --verbose      Print more information about what's happening during the process.
+  -t, --skip-tables  Comma delimited list of tables to skip imports of.
+  -r, --skip-drop    Skip dropping tables from the destination database.
+```
+
 ## Caveats
 
 This method sacrifices consistency for speed. If the source database is


### PR DESCRIPTION
Two new options have been added: `-r` and `-t` which allow you to skip the drop at the beginning of an import, and specify tables to skip the import of respectively.
